### PR TITLE
Parse innerXml correctly if there is another tag directly after the closing tag

### DIFF
--- a/context.ts
+++ b/context.ts
@@ -39,9 +39,19 @@ export class Attribute extends QName {
     }
 }
 
+class InnerXMLToken {
+    readonly startOffset: number;
+
+    constructor(startOffset: number) {
+        this.startOffset = startOffset;
+    }
+}
+
 export class Element extends QName {
     private _attributes: Attribute[] = [];
     private _parent?: Element;
+
+    innerXMLToken: InnerXMLToken | null = null;
 
     uri?: string;
     emptyElement = false;
@@ -141,11 +151,31 @@ export interface XMLLocator {
     position: XMLPosition;
 }
 
+class InnerXMLState {
+    pending: number = 0;
+    data: string;
+    dataIndex: number;
+
+    constructor(data: string, dataIndex: number) {
+        this.data = data;
+        this.dataIndex = dataIndex;
+    }
+
+    addChunk(chunk: string) {
+        this.data += chunk;
+    }
+
+    advance() {
+        this.dataIndex += 1;
+    }
+}
+
 export class XMLParseContext {
     private _locator?: XMLLocator;
     private _memento = '';
     private _elementStack: Element[] = [];
     private _namespaces: { [ns: string]: string | undefined } = {};
+    private _innerXML: InnerXMLState | null = null;
 
     quote: '' | '"' | '\'' = '';
     state = 'BEFORE_DOCUMENT';
@@ -197,6 +227,50 @@ export class XMLParseContext {
 
     getNamespaceURI(ns: string): string | undefined {
         return this._namespaces[ns];
+    }
+
+    get innerXML(): InnerXMLState | null {
+        return this._innerXML;
+    }
+
+    collectInnerXMLStart(element: ElementInfo, chunk: string, index: number) {
+        if (element.emptyElement) {
+            // Self-closing elements don't have innerXML
+            return;
+        }
+        if (this._innerXML === null) {
+            this._innerXML = new InnerXMLState(chunk, index);
+        }
+        const parserElement = this.peekElement();
+        if (parserElement === undefined) {
+            throw new Error('No current element');
+        }
+        // TODO: Make sure `parserElement` is `element._element`.
+        if (parserElement.innerXMLToken !== null) {
+            // Already collecting, ignore duplicate call
+            return;
+        }
+        this._innerXML.pending += 1;
+        parserElement.innerXMLToken = new InnerXMLToken(this._innerXML.dataIndex);
+    }
+
+    collectInnerXMLComplete(token: InnerXMLToken): string {
+        if (this._innerXML === null) {
+            throw new Error("collectInnerXMLComplete() without active collection");
+        }
+        // At the current position `this._innerXML.dataIndex` we have already read
+        // the closing tag. That tag shouldn't be incuded in innerXML and we have
+        // to remove it.
+        const closingTagStart = this._innerXML.data.lastIndexOf('<', this._innerXML.dataIndex);
+        if (closingTagStart < token.startOffset) {
+            throw new XMLParseError(`Closing tag missing in innerXML fragment: ${this._innerXML.data.substring(token.startOffset, this._innerXML.dataIndex)}`, this);
+        }
+        const collected = this._innerXML.data.substring(token.startOffset, closingTagStart);
+        this._innerXML.pending -= 1;
+        if (this._innerXML.pending === 0) {
+            this._innerXML = null;
+        }
+        return collected;
     }
 }
 

--- a/handler.ts
+++ b/handler.ts
@@ -29,6 +29,18 @@ export function resolveEntity(text: string): string {
     ].forEach(({ reg, ch }) => {
         result = result.replace(reg, ch);
     });
+    [
+        {
+            reg: /&#(\d{1,4});/g,
+            repl: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 10)),
+        },
+        {
+            reg: /&#x([\da-fA-F]{1,4});/g,
+            repl: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 16)),
+        },
+    ].forEach(({ reg, repl }) => {
+        result = result.replace(reg, repl);
+    });
     return result;
 }
 

--- a/handler.ts
+++ b/handler.ts
@@ -82,7 +82,7 @@ export function handleGeneralStuff(cx: XMLParseContext, c: string): XMLParseEven
 // FOUND_LT; SGML_DECL, START_TAG, END_TAG, PROC_INST, Error
 export function handleFoundLT(cx: XMLParseContext, c: string): XMLParseEvent[] {
     let events: XMLParseEvent[] = [];
-    const text = resolveEntity(cx.memento).trim();
+    const text = resolveEntity(cx.memento);
     cx.clearMemento();
     if (text) {
         events = [['text', text, new ElementInfo(cx.peekElement()!), false]];

--- a/handler.ts
+++ b/handler.ts
@@ -18,30 +18,43 @@ function isQuote(c: string): c is ('"' | '\'') {
     return c === '"' || c === '\'';
 }
 
+const simpleEntities = new Map<string, string>([
+    [ 'amp', '&' ],
+    [ 'gt', '>' ],
+    [ 'lt', '<' ],
+    [ 'quot', '"' ],
+    [ 'apos', '\'' ],
+]);
+const regexpEntities = [
+    {
+        regexp: /^#(\d{1,4})$/,
+        handler: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 10)),
+    },
+    {
+        regexp: /^#x([\da-fA-F]{1,4})$/,
+        handler: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 16)),
+    },
+];
+
 export function resolveEntity(text: string): string {
-    let result = text;
-    [
-        { reg: /&amp;/g, ch: '&' },
-        { reg: /&gt;/g, ch: '>' },
-        { reg: /&lt;/g, ch: '<' },
-        { reg: /&quot;/g, ch: '"' },
-        { reg: /&apos;/g, ch: '\'' },
-    ].forEach(({ reg, ch }) => {
-        result = result.replace(reg, ch);
+    return text.replace(/&([^;]*);/g, (complete: string, content: string) => {
+        // Named entities
+        const simpleValue = simpleEntities.get(content);
+        if (simpleValue !== undefined) {
+            return simpleValue;
+        }
+
+        // Numeric entities
+        for (const { regexp, handler } of regexpEntities) {
+            const match = content.match(regexp);
+            if (match !== null) {
+                return handler(match[0], match[1]);
+            }
+        }
+
+        // Unknown or invalid entities
+        return complete;
     });
-    [
-        {
-            reg: /&#(\d{1,4});/g,
-            repl: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 10)),
-        },
-        {
-            reg: /&#x([\da-fA-F]{1,4});/g,
-            repl: (_: string, digits: string) => String.fromCodePoint(parseInt(digits, 16)),
-        },
-    ].forEach(({ reg, repl }) => {
-        result = result.replace(reg, repl);
-    });
-    return result;
 }
 
 // BEFORE_DOCUMENT; FOUND_LT, Error

--- a/handler.ts
+++ b/handler.ts
@@ -305,6 +305,16 @@ export function handleStartTagStuff(cx: XMLParseContext, c: string): XMLParseEve
     return events;
 }
 
+function emitInnerXML(cx: XMLParseContext): XMLParseEvent[] {
+    let events: XMLParseEvent[] = [];
+    const element = cx.peekElement()!;
+    if (element.innerXMLToken !== null) {
+        const content = cx.collectInnerXMLComplete(element.innerXMLToken);
+        events = [['inner_xml', new ElementInfo(element), content]];
+    }
+    return events;
+}
+
 function emitEndElement(cx: XMLParseContext, qName: string): XMLParseEvent[] {
     let events: XMLParseEvent[] = [];
     const element = cx.popElement()!;
@@ -412,7 +422,7 @@ export function handleAttributeValueEnd(cx: XMLParseContext, c: string): XMLPars
 }
 
 function closeElement(cx: XMLParseContext): XMLParseEvent[] {
-    const events = emitEndElement(cx, cx.memento);
+    const events = emitInnerXML(cx).concat(emitEndElement(cx, cx.memento));
     cx.clearMemento();
     if (cx.elementLength === 0) {
         events.push(['end_document']);

--- a/handler_test.ts
+++ b/handler_test.ts
@@ -45,6 +45,14 @@ Deno.test('resolveEntity', () => {
     assertEquals(resolveEntity("a&#98;c"), "abc");
     assertEquals(resolveEntity("j&#x6b;l"), "jkl");
     assertEquals(resolveEntity("j&#x6B;l"), "jkl");
+
+    // Unknown/invalid entities stay unchanged
+    assertEquals(resolveEntity("n&unknown;p"), "n&unknown;p");
+    assertEquals(resolveEntity("n&#123xyz;p"), "n&#123xyz;p");
+    assertEquals(resolveEntity("n&#x123xyz;p"), "n&#x123xyz;p");
+    assertEquals(resolveEntity("n&ampx;p"), "n&ampx;p");
+    assertEquals(resolveEntity("n&xamp;p"), "n&xamp;p");
+    assertEquals(resolveEntity("n&;p"), "n&;p");
 });
 
 Deno.test('handleBeforeDocument', () => {

--- a/handler_test.ts
+++ b/handler_test.ts
@@ -53,6 +53,9 @@ Deno.test('resolveEntity', () => {
     assertEquals(resolveEntity("n&ampx;p"), "n&ampx;p");
     assertEquals(resolveEntity("n&xamp;p"), "n&xamp;p");
     assertEquals(resolveEntity("n&;p"), "n&;p");
+
+    // No recursive decoding of entities
+    assertEquals(resolveEntity("&amp;lt;"), "&lt;");
 });
 
 Deno.test('handleBeforeDocument', () => {

--- a/handler_test.ts
+++ b/handler_test.ts
@@ -42,6 +42,9 @@ Deno.test('resolveEntity', () => {
     assertEquals(resolveEntity('a&lt;b&gt;'), 'a<b>');
     assertEquals(resolveEntity('&quot;ab&quot;'), '"ab"');
     assertEquals(resolveEntity('&apos;ab&apos;'), '\'ab\'');
+    assertEquals(resolveEntity("a&#98;c"), "abc");
+    assertEquals(resolveEntity("j&#x6b;l"), "jkl");
+    assertEquals(resolveEntity("j&#x6B;l"), "jkl");
 });
 
 Deno.test('handleBeforeDocument', () => {

--- a/parser.ts
+++ b/parser.ts
@@ -162,11 +162,16 @@ export interface SAXEvent {
 /**
  * SAX-style XML parser.
  */
-export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> {
+export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array>, UnderlyingSink<string> {
     // deno-lint-ignore no-explicit-any
     private _listeners: { [name: string]: ((...arg: any[]) => void)[] } = {};
     private _controller?: WritableStreamDefaultController;
-    private _encoding?: string;
+    private _decoder: TextDecoder;
+
+    constructor(encoding: string = "UTF-8") {
+        super();
+        this._decoder = new TextDecoder(encoding);
+    }
 
     protected fireListeners(event: XMLParseEvent) {
         const [name, ...args] = event;
@@ -204,11 +209,29 @@ export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> 
      * @param chunk XML data chunk
      * @param controller error reporter, Deno writable stream uses internal.
      */
-    write(chunk: Uint8Array, controller?: WritableStreamDefaultController) {
+    write(chunk: Uint8Array|string, controller?: WritableStreamDefaultController) {
         try {
             this._controller = controller;
-            // TextDecoder can resolve BOM.
-            this.chunk = new TextDecoder(this._encoding).decode(chunk);
+            if (typeof chunk === 'string') {
+                this.chunk = chunk;
+            }
+            else {
+                // TextDecoder can resolve BOM.
+                this.chunk = this._decoder.decode(chunk, {stream: true});
+            }
+            this.run();
+        } finally {
+            this._controller = undefined;
+        }
+    }
+
+    close(controller?: WritableStreamDefaultController) {
+        try {
+            this._controller = controller;
+            // Process any remaining data still pending in `_decoder`
+            // Even if `_decoder` was unused because this parser processed strings,
+            // processing this empty chunk doesn't hurt.
+            this.chunk = this._decoder.decode(new Uint8Array(), {stream: false});
             this.run();
         } finally {
             this._controller = undefined;
@@ -220,18 +243,21 @@ export class SAXParser extends ParserBase implements UnderlyingSink<Uint8Array> 
      * @param source Target XML.
      * @param encoding When the source is Deno.Reader or Uint8Array, specify the encoding.
      */
-    async parse(source: ReadableStream<unknown> | Uint8Array | string, encoding?: string) {
-        this._encoding = encoding;
+    async parse(source: ReadableStream<Uint8Array> | ReadableStream<string> | Uint8Array | string, encoding?: string /** @deprecated Use constructor parameter instead */) {
+        if (encoding !== undefined) {
+            this._decoder = new TextDecoder(encoding);
+        }
         if (typeof source === 'string') {
             this.chunk = source;
             this.run();
         } else if (source instanceof Uint8Array) {
             this.write(source);
+            this.close();
         } else {
-            await source.pipeThrough(
-                new TextDecoderStream(this._encoding)
-            ).pipeTo(
-                new WritableStream<string>({ write: str => this.parse(str, encoding) }),
+            type ReadableStreamContent<T> = T extends ReadableStream<infer Content> ? Content : never;
+            type SourceStreamContent = ReadableStreamContent<typeof source>;
+            await source.pipeTo(
+                new WritableStream<SourceStreamContent>(this),
             );
         }
     }

--- a/parser.ts
+++ b/parser.ts
@@ -44,6 +44,11 @@ export abstract class ParserBase implements XMLLocator {
     private _index = -1;
     private _position: XMLPosition = { line: 1, column: 0 };
 
+    collectInnerXML(element: ElementInfo): void {
+        // Start collection after current character
+        this._cx.collectInnerXMLStart(element, this._chunk, this._index+1);
+    }
+
     /*
         The basic logic of this XML parser was obtained by reading the source code of sax-js.
         Thanks & see: https://github.com/isaacs/sax-js
@@ -118,6 +123,7 @@ export abstract class ParserBase implements XMLLocator {
     protected set chunk(chunk: string) {
         this._chunk = chunk;
         this._index = -1;
+        this._cx.innerXML?.addChunk(chunk);
     }
 
     protected hasNext(): boolean {
@@ -133,6 +139,7 @@ export abstract class ParserBase implements XMLLocator {
         } else {
             this._position.column += 1;
         }
+        this._cx.innerXML?.advance();
         return c;
     }
 
@@ -156,6 +163,7 @@ export interface SAXEvent {
     end_element: (element: ElementInfo) => void;
     end_prefix_mapping: (ns: string, uri: string) => void;
     end_document: () => void;
+    inner_xml: (element: ElementInfo, content: string) => void;
     error: (error: XMLParseError) => void;
 }
 

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -221,6 +221,7 @@ Deno.test('SAXParser innerXML collection', () => {
             <d>dd<e>ee</e>DD</d>
             <f>ff<g/>FF</f>
             <h>  <i attr="ii">  </i> </h>
+            <j>t1</j><k>t2</k><l/><m>t3</m>
         </xml>`
         );
 
@@ -233,8 +234,15 @@ Deno.test('SAXParser innerXML collection', () => {
     assert(!contents.has('g'));
     assertEquals(contents.get('h'), '  <i attr="ii">  </i> ');
     assertEquals(contents.get('i'), '  ');
+
+    // Test tags without spaces between
+    assertEquals(contents.get('j'), 't1');
+    assertEquals(contents.get('k'), 't2');
+    assert(!contents.has('l'));
+    assertEquals(contents.get('m'), 't3');
+
     assert(contents.has('xml'));
-    assertEquals(contents.size, 8);
+    assertEquals(contents.size, 11);
 });
 
 Deno.test('SAXParser innerXML collection with chunked data', async () => {

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -203,6 +203,74 @@ Deno.test('SAXParser entity resolution', () => {
     assertEquals(flag_attr, true);
 });
 
+Deno.test('SAXParser innerXML collection', () => {
+    const parser = new SAXParser();
+    const contents = new Map<string, string>();
+    parser.on('start_element', (element) => {
+        parser.collectInnerXML(element);
+    });
+    parser.on('inner_xml', (element, content) => {
+       contents.set(element.qName, content);
+    });
+
+    parser.parse(
+        `<xml>
+            <a>aaaa</a>
+            <b></b>
+            <c/>
+            <d>dd<e>ee</e>DD</d>
+            <f>ff<g/>FF</f>
+            <h>  <i attr="ii">  </i> </h>
+        </xml>`
+        );
+
+    assertEquals(contents.get('a'), 'aaaa');
+    assertEquals(contents.get('b'), '');
+    assert(!contents.has('c'));
+    assertEquals(contents.get('d'), 'dd<e>ee</e>DD');
+    assertEquals(contents.get('e'), 'ee');
+    assertEquals(contents.get('f'), 'ff<g/>FF');
+    assert(!contents.has('g'));
+    assertEquals(contents.get('h'), '  <i attr="ii">  </i> ');
+    assertEquals(contents.get('i'), '  ');
+    assert(contents.has('xml'));
+    assertEquals(contents.size, 8);
+});
+
+Deno.test('SAXParser innerXML collection with chunked data', async () => {
+    const parser = new SAXParser();
+    const contents = new Map<string, string>();
+    parser.on('start_element', (element) => {
+        parser.collectInnerXML(element);
+    });
+    parser.on('inner_xml', (element, content) => {
+        contents.set(element.qName, content);
+    });
+
+    await parser.parse(charChunkStream(
+        `<xml>
+            <a>aaaa</a>
+            <b></b>
+            <c/>
+            <d>dd<e>ee</e>DD</d>
+            <f>ff<g/>FF</f>
+            <h>  <i attr="ii">  </i> </h>
+        </xml>`
+        ));
+
+    assertEquals(contents.get('a'), 'aaaa');
+    assertEquals(contents.get('b'), '');
+    assert(!contents.has('c'));
+    assertEquals(contents.get('d'), 'dd<e>ee</e>DD');
+    assertEquals(contents.get('e'), 'ee');
+    assertEquals(contents.get('f'), 'ff<g/>FF');
+    assert(!contents.has('g'));
+    assertEquals(contents.get('h'), '  <i attr="ii">  </i> ');
+    assertEquals(contents.get('i'), '  ');
+    assert(contents.has('xml'));
+    assertEquals(contents.size, 8);
+});
+
 Deno.test('marshallEvent', () => {
     class TestParser extends PullParser {
         override marshallEvent(event: XMLParseEvent): PullResult {

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -20,6 +20,52 @@ import {
     PullResult,
 } from './parser.ts';
 
+function byteChunkStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
+    return new ReadableStream<Uint8Array>({
+        start(controller: ReadableStreamDefaultController) {
+            for (let pos = 0; pos < bytes.length; ++pos) {
+                controller.enqueue(bytes.subarray(pos, pos+1));
+            }
+            controller.close();
+        }
+    });
+}
+
+function charChunkStream(str: string): ReadableStream<string> {
+    return new ReadableStream<string>({
+        start(controller: ReadableStreamDefaultController) {
+            for (let pos = 0; pos < str.length; ++pos) {
+                controller.enqueue(str.substring(pos, pos+1));
+            }
+            controller.close();
+        }
+    });
+}
+
+Deno.test('byteChunkStream writes single byte chunks', async () => {
+    const input = (new TextEncoder()).encode("abc");
+    const stream = byteChunkStream(input);
+    const output = new Uint8Array(input.length);
+    let outputpos = 0;
+    for await (const chunk of stream) {
+        assertEquals(chunk.length, 1);
+        output.set(chunk, outputpos);
+        outputpos += chunk.length;
+    }
+    assertEquals(output, input);
+});
+
+Deno.test('charChunkStream writes single char chunks', async () => {
+    const input = "abc";
+    const stream = charChunkStream(input);
+    let output = "";
+    for await (const chunk of stream) {
+        assertEquals(chunk.length, 1);
+        output = output + chunk;
+    }
+    assertEquals(output, input);
+});
+
 Deno.test('ParserBase chunk & hasNext & readNext & position', () => {
     // protected -> public visiblity
     class TestParser extends ParserBase {
@@ -72,6 +118,36 @@ Deno.test('SAXParser on & parse(Deno.Reader)', async () => {
     await parser.parse(file.readable);
     assertEquals(assertionCount, 3);
     assertEquals(elementCount, 18);
+});
+
+Deno.test('SAXParser UnderlyingSink chunks', async () => {
+    const parser = new SAXParser();
+
+    const input = (new TextEncoder()).encode("<x>ä</x>");
+    parser.on('text', (text) => {
+        assertEquals(text, "\u00E4");
+    });
+    await byteChunkStream(input).pipeTo(new WritableStream(parser));
+});
+
+Deno.test('SAXParser parse(ReadableStream<Uint8Array>)', async () => {
+    const parser = new SAXParser();
+    parser.on('text', (text) => {
+        assertEquals(text, "\u00E4");
+    });
+
+    const input = (new TextEncoder()).encode("<x>ä</x>");
+    await parser.parse(byteChunkStream(input));
+});
+
+Deno.test('SAXParser parse(ReadableStream<string>)', async () => {
+    const parser = new SAXParser();
+    parser.on('text', (text) => {
+        assertEquals(text, "\u00E4");
+    });
+
+    const input = "<x>ä</x>";
+    await parser.parse(charChunkStream(input));
 });
 
 Deno.test('SAXParser parse(Uint8Array)', () => {

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -182,6 +182,27 @@ Deno.test('SAXParser self-closing end_document', () => {
     assertEquals(flag, true);
 });
 
+Deno.test('SAXParser entity resolution', () => {
+    const parser = new SAXParser();
+    let flag_text = false;
+    let flag_attr = false;
+    parser.on('text', (text) => {
+        flag_text = true;
+        assertEquals(text, "text&text");
+    });
+    parser.on('start_element', (element) => {
+        for (const attr of element.attributes) {
+            if (attr.qName == "attr") {
+                flag_attr = true;
+                assertEquals(attr.value, "attr&attr");
+            }
+        }
+    });
+    parser.parse('<xml attr="attr&amp;attr">text&amp;text</xml>');
+    assertEquals(flag_text, true);
+    assertEquals(flag_attr, true);
+});
+
 Deno.test('marshallEvent', () => {
     class TestParser extends PullParser {
         override marshallEvent(event: XMLParseEvent): PullResult {

--- a/parser_test.ts
+++ b/parser_test.ts
@@ -271,6 +271,16 @@ Deno.test('SAXParser innerXML collection with chunked data', async () => {
     assertEquals(contents.size, 8);
 });
 
+Deno.test('SAXParser white space handling', () => {
+    const parser = new SAXParser();
+    const expectedTexts = [' ', ' a ', '  ', '   '];
+    parser.on('text', (text) => {
+        assertEquals(text, expectedTexts.shift());
+    });
+    parser.parse('<xml> <a> a </a>  <b/>   </xml>');
+    assertEquals(expectedTexts.length, 0);
+});
+
 Deno.test('marshallEvent', () => {
     class TestParser extends PullParser {
         override marshallEvent(event: XMLParseEvent): PullResult {
@@ -303,7 +313,9 @@ Deno.test('PullParser', async () => {
     assertEquals(events.next().value, { name: 'start_prefix_mapping', ns: 'atom', uri: 'http://www.w3.org/2005/Atom' });
     assertEquals(events.next().value, { name: 'start_prefix_mapping', ns: 'm', uri: 'https://xmlp.test/m' });
     assertEquals((events.next().value as PullResult).element!.qName, 'rss');
+    assertEquals((events.next().value as PullResult).text!.trim(), '');
     assertEquals((events.next().value as PullResult).element!.qName, 'channel');
+    assertEquals((events.next().value as PullResult).text!.trim(), '');
     assertEquals((events.next().value as PullResult).element!.qName, 'title');
     assertEquals((events.next().value as PullResult).text, 'XML Parser for Deno');
     assertEquals((events.next().value as PullResult).name, 'end_element');


### PR DESCRIPTION
In this case the closing tag is currently not recognized correctly and not removed from the captured xml fragment.